### PR TITLE
Update library for PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/ethul/purescript-freeap.git"
+    "url": "https://github.com/ethul/purescript-freeap.git"
   },
   "dependencies": {
     "purescript-exists": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
   "purescript-integers": "^5.0.0",
   "purescript-console": "^5.0.0",
   "purescript-exceptions": "^5.0.0",
-  "purescript-quickcheck-laws": "^v6.0.0"
+  "purescript-quickcheck-laws": "^6.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -10,16 +10,16 @@
     "url": "https://github.com/ethul/purescript-freeap.git"
   },
   "dependencies": {
-    "purescript-exists": "^4.0.0",
-    "purescript-const": "^4.0.0",
-    "purescript-lists": "^5.0.0",
-    "purescript-gen": "^2.0.0"
+    "purescript-exists": "master",
+    "purescript-const": "master",
+    "purescript-lists": "master",
+    "purescript-gen": "master"
   },
   "devDependencies": {
-    "purescript-either": "^4.0.0",
-    "purescript-integers": "^4.0.0",
-    "purescript-console": "^4.1.0",
-    "purescript-exceptions": "^4.0.0",
-    "purescript-quickcheck-laws": "paulyoung/purescript-quickcheck-laws#compiler/0.12"
+    "purescript-either": "master",
+    "purescript-integers": "master",
+    "purescript-console": "master",
+    "purescript-exceptions": "master",
+    "purescript-quickcheck-laws": "thomashoneyman/purescript-quickcheck-laws#master"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -10,16 +10,16 @@
     "url": "https://github.com/ethul/purescript-freeap.git"
   },
   "dependencies": {
-    "purescript-exists": "master",
-    "purescript-const": "master",
-    "purescript-lists": "master",
-    "purescript-gen": "master"
+    "purescript-exists": "^5.0.0",
+    "purescript-const": "^5.0.0",
+    "purescript-lists": "^6.0.0",
+    "purescript-gen": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-either": "master",
-    "purescript-integers": "master",
-    "purescript-console": "master",
-    "purescript-exceptions": "master",
-    "purescript-quickcheck-laws": "master"
+  "purescript-either": "^5.0.0",
+  "purescript-integers": "^5.0.0",
+  "purescript-console": "^5.0.0",
+  "purescript-exceptions": "^5.0.0",
+  "purescript-quickcheck-laws": "^v6.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,10 @@
     "purescript-gen": "^3.0.0"
   },
   "devDependencies": {
-  "purescript-either": "^5.0.0",
-  "purescript-integers": "^5.0.0",
-  "purescript-console": "^5.0.0",
-  "purescript-exceptions": "^5.0.0",
-  "purescript-quickcheck-laws": "^6.0.0"
+    "purescript-either": "^5.0.0",
+    "purescript-integers": "^5.0.0",
+    "purescript-console": "^5.0.0",
+    "purescript-exceptions": "^5.0.0",
+    "purescript-quickcheck-laws": "^6.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "purescript-integers": "master",
     "purescript-console": "master",
     "purescript-exceptions": "master",
-    "purescript-quickcheck-laws": "thomashoneyman/purescript-quickcheck-laws#master"
+    "purescript-quickcheck-laws": "master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "pulp": "^15.0.0",
-    "purescript-psa": "^0.8.0",
+    "purescript-psa": "^0.8.2",
     "rimraf": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "build": "pulp build -- --censor-lib --strict"
   },
   "devDependencies": {
-    "pulp": "^12.2.0",
-    "purescript-psa": "^0.6.0",
-    "rimraf": "^2.6.2"
+    "pulp": "^15.0.0",
+    "purescript-psa": "^0.8.0",
+    "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
👋 Hi @ethul!

This PR updates `freeap` for compatibility with PureScript 0.14. I've opened this pull request instead of waiting for the official release because Halogen depends on this library, and I think users would really appreciate being able to use Halogen right off the bat when PureScript 0.14 is released.

Specifically, this PR updates library dependencies to the relevant master branches (other than `quickcheck-laws`, which is awaiting https://github.com/garyb/purescript-quickcheck-laws/pull/53).

I also took the extra step of updating the repository URL in the Bower file so that it matches the [PureScript registry](https://github.com/purescript/registry). The URL in your local Bower file must match the URL in the registry in order for you to publish new versions of the library to Pursuit.

---

When PureScript 0.14 is released, then you'll still have to make a new release of this library; luckily, if this PR is already merged then you'll only need to take these steps:

1. Update your Bower file to point to the new major versions of your dependencies, instead of `master`
2. Commit and tag a new major version of this library
3. (Optionally) publish the new documentation to Pursuit with `pulp publish`

I can circle back when we've released new versions of your dependencies and update your Bower file. Then, once you've made a release of your own, I can update the relevant downstream libraries and ensure `freeap` is up to date in the package sets.

Please let me know if I can be helpful with any other step!